### PR TITLE
Implement can_execute for MoveCommand

### DIFF
--- a/santorini-common/src/command.rs
+++ b/santorini-common/src/command.rs
@@ -43,7 +43,13 @@ impl Command for MovementCommand {
         // TODO
 
         // 4) it is a valid move in one of the 8 directions
-        // TODO
+        if !&self.to.adjacent_to(&self.from) {
+            return Err(SantoriniError::InvalidMovement {
+                from: self.from,
+                to: self.to,
+                details: "The given positions are not adjacent".into(),
+            });
+        }
 
         // 5) the `to` space is not occupied by another worker
         if state.space(&self.to).worker().is_some() {
@@ -171,6 +177,20 @@ mod tests {
             .with_current_player(Player::Red)
             .add_red_worker(from)
             .add_blue_worker(to)
+            .build();
+
+        assert!(cmd.can_execute(&state).is_err())
+    }
+
+    #[test]
+    fn it_errors_if_nonadjacent() {
+        let from = Position::new(Row::One, Column::A);
+        let to = Position::new(Row::One, Column::C);
+        let cmd = MovementCommand { from, to };
+
+        let state = StateBuilder::new()
+            .with_current_player(Player::Red)
+            .add_red_worker(from)
             .build();
 
         assert!(cmd.can_execute(&state).is_err())

--- a/santorini-common/src/command.rs
+++ b/santorini-common/src/command.rs
@@ -1,13 +1,11 @@
 use crate::{
     error::SantoriniError,
-    objects::{
-        state::State,
-        tower::{Dome, Level},
-    },
-    position::Position,
+    objects::{state::State, tower::*},
+    position::*,
 };
 
 pub trait Command {
+    fn can_execute(&self, state: &State) -> Result<(), SantoriniError>;
     fn execute(&self, state: &mut State) -> Result<(), SantoriniError>;
     fn undo(&self, state: &mut State) -> Result<(), SantoriniError>;
 }
@@ -18,14 +16,21 @@ pub struct MovementCommand {
 }
 
 impl Command for MovementCommand {
-    fn execute(&self, state: &mut State) -> Result<(), SantoriniError> {
-        let worker = state
-            .mut_space(&self.from)
-            .mut_worker()
-            .take()
-            .ok_or_else(|| {
-                SantoriniError::InvalidArgument(format!("There is no worker at {}", self.from,))
-            })?;
+    fn can_execute(&self, state: &State) -> Result<(), SantoriniError> {
+        // A move can execute if
+
+        // 1) the `from` space has a worker
+        let worker = match state.space(&self.from).worker() {
+            Some(worker) => worker,
+            None => {
+                return Err(SantoriniError::InvalidArgument(format!(
+                    "There is no worker at {}",
+                    self.from
+                )));
+            }
+        };
+
+        // 2) the worker belongs to the current player's turn
         if worker.player() != state.current_player() {
             return Err(SantoriniError::InvalidArgument(format!(
                 "Current player {} cannot control {} worker.",
@@ -33,13 +38,55 @@ impl Command for MovementCommand {
                 worker.player()
             )));
         }
-        let previous = state.mut_space(&self.to).mut_worker().replace(worker);
-        if previous.is_some() {
+
+        // 3) it is a move phase
+        // TODO
+
+        // 4) it is a valid move in one of the 8 directions
+        // TODO
+
+        // 5) the `to` space is not occupied by another worker
+        if state.space(&self.to).worker().is_some() {
             return Err(SantoriniError::InvalidMovement {
                 from: self.from,
                 to: self.to,
+                details: "There is a worker blocking the move".into(),
             });
         }
+
+        // 6) `to` space is not Domed
+        if state.space(&self.to).tower().dome().is_some() {
+            return Err(SantoriniError::InvalidMovement {
+                from: self.from,
+                to: self.to,
+                details: "There is a dome blocking the move".into(),
+            });
+        }
+
+        // 7) level of the `to` space <= level of the `from` space + 1
+        let to_level = state.space(&self.to).tower().level();
+        let from_level = state.space(&self.from).tower().level();
+        if to_level > from_level.up() {
+            return Err(SantoriniError::InvalidMovement {
+                from: self.from,
+                to: self.to,
+                details: format!(
+                    "Cannot move from level {} to level {}",
+                    from_level, to_level
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn execute(&self, state: &mut State) -> Result<(), SantoriniError> {
+        self.can_execute(state)?;
+
+        // Safely unwrap since we check can_execute?
+        let worker = state.mut_space(&self.from).mut_worker().take().unwrap();
+        state.mut_space(&self.to).mut_worker().replace(worker);
+
         Ok(())
     }
 
@@ -54,6 +101,10 @@ pub struct BuildCommand {
 }
 
 impl Command for BuildCommand {
+    fn can_execute(&self, _state: &State) -> Result<(), SantoriniError> {
+        panic!("Unimplemented")
+    }
+
     fn execute(&self, state: &mut State) -> Result<(), SantoriniError> {
         let tower = state.mut_space(&self.position).mut_tower();
         if tower.dome().is_some() {

--- a/santorini-common/src/error.rs
+++ b/santorini-common/src/error.rs
@@ -10,8 +10,12 @@ pub enum SantoriniError {
     #[error("Invalid build on position: {0}")]
     InvalidBuild(Position),
 
-    #[error("Invalid movement from {from} to {to}")]
-    InvalidMovement { from: Position, to: Position },
+    #[error("Invalid movement from {from} to {to}: {details}")]
+    InvalidMovement {
+        from: Position,
+        to: Position,
+        details: String,
+    },
 
     #[error(transparent)]
     Other(#[from] std::io::Error),

--- a/santorini-common/src/objects/state.rs
+++ b/santorini-common/src/objects/state.rs
@@ -87,11 +87,17 @@ pub struct StateBuilder {
     red_workers: Vec<Position>,
     blue_workers: Vec<Position>,
     towers: Vec<(Position, Tower)>,
+    current_player: Player,
 }
 
 impl StateBuilder {
     pub fn new() -> StateBuilder {
         StateBuilder::default()
+    }
+
+    pub fn with_current_player(mut self, player: Player) -> StateBuilder {
+        self.current_player = player;
+        self
     }
 
     pub fn add_red_worker(mut self, position: Position) -> StateBuilder {
@@ -111,6 +117,9 @@ impl StateBuilder {
 
     pub fn build(self) -> State {
         let mut state = State::default();
+
+        state.current_player = self.current_player;
+
         for position in self.red_workers {
             state
                 .mut_space(&position)

--- a/santorini-common/src/objects/state.rs
+++ b/santorini-common/src/objects/state.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use super::{player::Player, space::Space, tower::Level, worker::Worker};
+use super::{
+    player::Player,
+    space::Space,
+    tower::{Level, Tower},
+    worker::Worker,
+};
 use crate::{
     command::Command,
     error::SantoriniError,
@@ -81,6 +86,7 @@ impl State {
 pub struct StateBuilder {
     red_workers: Vec<Position>,
     blue_workers: Vec<Position>,
+    towers: Vec<(Position, Tower)>,
 }
 
 impl StateBuilder {
@@ -98,6 +104,11 @@ impl StateBuilder {
         self
     }
 
+    pub fn add_tower(mut self, position: Position, tower: Tower) -> StateBuilder {
+        self.towers.push((position, tower));
+        self
+    }
+
     pub fn build(self) -> State {
         let mut state = State::default();
         for position in self.red_workers {
@@ -111,6 +122,10 @@ impl StateBuilder {
                 .mut_space(&position)
                 .mut_worker()
                 .replace(Worker::new(Player::Blue));
+        }
+
+        for (position, tower) in self.towers {
+            *(state.mut_space(&position).mut_tower()) = tower;
         }
         state
     }

--- a/santorini-common/src/objects/tower.rs
+++ b/santorini-common/src/objects/tower.rs
@@ -16,7 +16,7 @@ impl fmt::Display for Tower {
         if self.dome.is_some() {
             write!(f, "D")
         } else {
-            write!(f, "{}", self.level as usize)
+            self.level.fmt(f)
         }
     }
 }
@@ -39,7 +39,7 @@ impl Tower {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Level {
     Ground = 0,
     One = 1,
@@ -50,5 +50,21 @@ pub enum Level {
 impl Default for Level {
     fn default() -> Level {
         Level::Ground
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", *self as usize)
+    }
+}
+
+impl Level {
+    pub fn up(self) -> Level {
+        match self {
+            Level::Ground => Level::One,
+            Level::One => Level::Two,
+            Level::Two | Level::Three => Level::Three,
+        }
     }
 }

--- a/santorini-common/src/objects/tower.rs
+++ b/santorini-common/src/objects/tower.rs
@@ -7,8 +7,8 @@ pub struct Dome;
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Tower {
-    dome: Option<Dome>,
-    level: Level,
+    pub dome: Option<Dome>,
+    pub level: Level,
 }
 
 impl fmt::Display for Tower {

--- a/santorini-common/src/position.rs
+++ b/santorini-common/src/position.rs
@@ -2,7 +2,7 @@ use std::{convert::TryFrom, fmt};
 
 use crate::error::SantoriniError;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Position(pub Column, pub Row);
 
 impl Position {
@@ -25,6 +25,16 @@ impl Position {
     pub fn column_index(&self) -> usize {
         self.column() as usize
     }
+
+    pub fn adjacent_to(&self, other: &Position) -> bool {
+        if self == other {
+            false
+        } else {
+            let column_delta = (self.column_index() as i32 - other.column_index() as i32).abs();
+            let row_delta = (self.row_index() as i32 - other.row_index() as i32).abs();
+            column_delta <= 1 && row_delta <= 1
+        }
+    }
 }
 
 impl fmt::Display for Position {
@@ -33,7 +43,7 @@ impl fmt::Display for Position {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Column {
     A = 0,
     B = 1,
@@ -73,7 +83,7 @@ impl TryFrom<char> for Column {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Row {
     Zero = 0,
     One = 1,
@@ -109,6 +119,34 @@ impl TryFrom<char> for Row {
             '3' => Ok(Row::Three),
             '4' => Ok(Row::Four),
             _ => Err(SantoriniError::InvalidArgument(value.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_computes_adjacency_correctly() {
+        let adj = [
+            Position::new(Row::Zero, Column::A),
+            Position::new(Row::One, Column::A),
+            Position::new(Row::Zero, Column::B),
+            Position::new(Row::One, Column::B),
+        ];
+        let far = Position::new(Row::Four, Column::E);
+
+        for i in 0..adj.len() {
+            for j in 0..adj.len() {
+                assert!((i == j) ^ &adj[i].adjacent_to(&adj[j]));
+                assert!((i == j) ^ &adj[j].adjacent_to(&adj[i]));
+            }
+        }
+
+        for pos in &adj {
+            assert!(!pos.adjacent_to(&far));
+            assert!(!&far.adjacent_to(pos));
         }
     }
 }


### PR DESCRIPTION
## Summary
Separate out validation logic for MoveCommand into `can_execute`. Some items still unimplemented. Also unimplemented for BuildCommand. It's likely we'll want to abstract some of these into helpers, e.g. `space_unblocked` to share with BuildCommand.can_execute, but leaving to future PRs.

## Tests
Unit tests